### PR TITLE
Add feature to be able to open typeAhead search drop-down programmatically

### DIFF
--- a/src/LoreSoft.Blazor.Controls/Typeahead.razor
+++ b/src/LoreSoft.Blazor.Controls/Typeahead.razor
@@ -6,7 +6,8 @@
 
 <div class="typeahead-container @ValidationClass()"
      @attributes="AdditionalAttributes">
-    <div class="typeahead-control"
+    <div @ref="TypeaheadControl" 
+        class="typeahead-control"
          tabindex="0"
          @onfocus="HandleFocus">
         <div class="typeahead-value-container">

--- a/src/LoreSoft.Blazor.Controls/Typeahead.razor.cs
+++ b/src/LoreSoft.Blazor.Controls/Typeahead.razor.cs
@@ -111,6 +111,8 @@ namespace LoreSoft.Blazor.Controls
 
         public ElementReference SearchInput { get; set; }
 
+        public ElementReference TypeaheadControl;
+
 
         private string _searchText;
 
@@ -234,6 +236,14 @@ namespace LoreSoft.Blazor.Controls
                 await ValueChanged.InvokeAsync(default);
 
             EditContext?.NotifyFieldChanged(FieldIdentifier);
+        }
+
+        /// <summary>
+        /// This will set focus to typeahead and open the search dropdown
+        /// </summary>
+        public async Task FocusTypeahead()
+        {
+            await JSRuntime.InvokeAsync<object>("BlazorControls.setFocus", TypeaheadControl);
         }
 
         public async Task HandleFocus()


### PR DESCRIPTION
This PR makes it possible that you can open the search box programmatically.

For example, I added shortcuts to my web app, and when user presses Alt + E I want to focus and open the typeAhead. This PR makes that possible.