### PR TITLE
Fix crash exception in Typeahead.SearchMethod

### DIFF
--- a/src/LoreSoft.Blazor.Controls/Typeahead.razor.cs
+++ b/src/LoreSoft.Blazor.Controls/Typeahead.razor.cs
@@ -167,7 +167,7 @@ namespace LoreSoft.Blazor.Controls
             _debounceTimer = new Timer();
             _debounceTimer.Interval = Debounce;
             _debounceTimer.AutoReset = false;
-            _debounceTimer.Elapsed += Search;
+            _debounceTimer.Elapsed += (s, e) => InvokeAsync(() => Search(s, e));
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -182,7 +182,7 @@ namespace LoreSoft.Blazor.Controls
         public async void Search(object source, ElapsedEventArgs e)
         {
             Loading = true;
-            await InvokeAsync(StateHasChanged);
+            StateHasChanged();
 
             var result = await SearchMethod(_searchText);
 
@@ -191,7 +191,7 @@ namespace LoreSoft.Blazor.Controls
                 : result.ToList();
 
             Loading = false;
-            await InvokeAsync(StateHasChanged);
+            StateHasChanged();
         }
 
         public async Task SelectResult(TItem item)


### PR DESCRIPTION
Hello. Thank for your work. I would like to push a fix in Typeahead component.

**Reproduce**: define a Typeahead component that throws an exception in `SearchMethod`. In my real case scenario, this method uses a repository calling an API, so a timeout might be raised.

**Effect**: the whole Blazor server will crash.

**Fix**: the handling of `_debounceTimer.Elapsed` should be done on the rendering thread, rather than on a worker thread where the exception will go unhandled and crash the application. Now the exception is gracefully handled by Blazor framework.